### PR TITLE
Fixed compatibility with Android Studio 3.1 and IntelliJ 2017.3

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
-<idea-plugin version="8">
+<idea-plugin>
 	<id>com.weezlabs.intentSender</id>
 	<name>Android Intent Sender</name>
-	<version>0.7.0</version>
+	<version>0.8.0</version>
 	<vendor email="vfarafonov@weezlabs.com" url="https://weezlabs.com">Weezlabs</vendor>
 
 	<description><![CDATA[
@@ -11,6 +11,10 @@
 
 	<change-notes><![CDATA[
       <html>
+        <dl>
+            <dt>0.8.0</dt>
+            <dd>Fixed compatibility with IntelliJ 2017.3 and Android Studio 3.1<dd>
+        </dl>
         <dl>
             <dt>0.7.0 - 0.5.0</dt>
             <dd>Minor fixes<dd>
@@ -29,7 +33,7 @@
 	</change-notes>
 
 	<!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-	<idea-version since-build="131"/>
+	<idea-version since-build="173"/>
 
 	<!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
 		   on how to target different products -->

--- a/src/adb/AdbHelper.java
+++ b/src/adb/AdbHelper.java
@@ -6,9 +6,8 @@ import com.android.ddmlib.IDevice;
 import com.android.ddmlib.IShellOutputReceiver;
 import com.android.ddmlib.ShellCommandUnresponsiveException;
 import com.android.ddmlib.TimeoutException;
+import com.android.tools.idea.sdk.AndroidSdks;
 import com.intellij.ide.util.PropertiesComponent;
-
-import org.jetbrains.android.sdk.AndroidSdkUtils;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -65,9 +64,9 @@ public class AdbHelper {
 				return adbPath;
 			}
 		}
-		Collection<String> sdkList = AndroidSdkUtils.getAndroidSdkPathsFromExistingPlatforms();
+		Collection<File> sdkList = AndroidSdks.getInstance().getAndroidSdkPathsFromExistingPlatforms();
 		if (sdkList.size() > 0) {
-			String sdkPath = sdkList.iterator().next() + ADB_PATH_RELATIVE_TO_SDK_ROOT;
+			String sdkPath = sdkList.iterator().next().getPath() + ADB_PATH_RELATIVE_TO_SDK_ROOT;
 			if (checkForAdbInPath(sdkPath)) {
 				saveAdbLocation(sdkPath);
 				return sdkPath;


### PR DESCRIPTION
The API was changed in IntelliJ 2017.3 and the plug-in stopped working.
With this quick modification, it's working again !